### PR TITLE
Render issuer signatures from base64 strings in CertificateTemplate

### DIFF
--- a/src/app/certificate/[credentialId]/page.tsx
+++ b/src/app/certificate/[credentialId]/page.tsx
@@ -9,6 +9,7 @@ type Certificate = {
   course: string;
   dateIssued: string;
   issuer: string;
+  signatures?: { image_b64: string }[];
 };
 
 export default function CertificateDetailsPage() {
@@ -26,7 +27,7 @@ export default function CertificateDetailsPage() {
         const res = await fetch(`${baseUrl}/api/certificate/${credentialId}`);
         if (!res.ok) throw new Error("Certificate not found");
         const data = await res.json();
-        setCertificate(data);
+        setCertificate(data); // store entire certificate, including signatures
       } catch (err: unknown) {
         if (err instanceof Error) {
           setError(err.message);
@@ -55,6 +56,8 @@ export default function CertificateDetailsPage() {
           course={certificate.course}
           dateIssued={certificate.dateIssued}
           description={`This is to certify that ${certificate.name} has contributed as a ${certificate.course}.`}
+          signatureLeft={certificate.signatures?.[0]?.image_b64}
+          signatureRight={certificate.signatures?.[1]?.image_b64}
         />
       ) : (
         <div className="text-center">Certificate not found</div>
@@ -62,4 +65,5 @@ export default function CertificateDetailsPage() {
     </div>
   );
 }
+
 // ...existing code...

--- a/src/app/components/CertificateTemplate.tsx
+++ b/src/app/components/CertificateTemplate.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Image from "next/image";
 
 type CertificateTemplateProps = {
   name: string;
@@ -9,6 +10,8 @@ type CertificateTemplateProps = {
   issuerRight?: string;
   issuerRightRole?: string;
   description?: string;
+  signatureLeft?: string; // base64 image
+  signatureRight?: string; // base64 image
 };
 
 export default function CertificateTemplate({
@@ -20,6 +23,8 @@ export default function CertificateTemplate({
   issuerRight = "Mohamed Asath",
   issuerRightRole = "Secretary",
   description = "We give this certificate because the recipient has participated in a social event that we organize.",
+  signatureLeft,
+  signatureRight,
 }: CertificateTemplateProps) {
   return (
     <div className="w-full max-w-[900px] mx-auto aspect-[16/9]">
@@ -52,8 +57,12 @@ export default function CertificateTemplate({
             style={{ objectFit: "contain" }}
           />
           <div className="flex flex-row items-center justify-center w-full mb-1 mt-1">
-            <span className="text-[1.7vw] font-normal tracking-widest text-[#223] uppercase mr-2">CERTIFICATE</span>
-            <span className="text-[1.7vw] font-normal tracking-widest text-[#223] uppercase">of Appreciation</span>
+            <span className="text-[1.7vw] font-normal tracking-widest text-[#223] uppercase mr-2">
+              CERTIFICATE
+            </span>
+            <span className="text-[1.7vw] font-normal tracking-widest text-[#223] uppercase">
+              of Appreciation
+            </span>
           </div>
           <div className="text-[0.9vw] font-medium text-[#222] mb-3 tracking-wide">
             We are proudly present this to
@@ -64,8 +73,21 @@ export default function CertificateTemplate({
           <div className="text-center text-[0.8vw] text-[#222] mb-3 max-w-[90%]">
             {description}
           </div>
+
+          {/* Signature and Medal Section */}
           <div className="flex justify-between items-end w-full mt-4 px-2">
+            {/* Left issuer */}
             <div className="flex flex-col items-center">
+              {signatureLeft && (
+                <Image
+                  src={signatureLeft}
+                  alt="Left Signature"
+                  width={100}
+                  height={50}
+                  className="mb-1"
+                  style={{ objectFit: "contain" }}
+                />
+              )}
               <div className="border-t border-black w-[10vw] mb-1" />
               <div className="font-semibold text-black text-[0.9vw]">
                 {issuerLeft}
@@ -74,6 +96,7 @@ export default function CertificateTemplate({
                 {issuerLeftRole}
               </div>
             </div>
+
             {/* Medal/Seal */}
             <div className="flex flex-col items-center">
               <svg
@@ -96,7 +119,19 @@ export default function CertificateTemplate({
                 {new Date(dateIssued).toLocaleDateString()}
               </div>
             </div>
+
+            {/* Right issuer */}
             <div className="flex flex-col items-center">
+              {signatureRight && (
+                <Image
+                  src={signatureRight}
+                  alt="Right Signature"
+                  width={100}
+                  height={50}
+                  className="mb-1"
+                  style={{ objectFit: "contain" }}
+                />
+              )}
               <div className="border-t border-black w-[10vw] mb-1" />
               <div className="font-semibold text-black text-[0.9vw]">
                 {issuerRight}


### PR DESCRIPTION
This PR updates the CertificateTemplate component to render issuer signatures using base64 encoded images instead of static `<img>` sources, allowing dynamic display of signatures fetched from the backend.